### PR TITLE
Add profile command for provider profile URL updates

### DIFF
--- a/commands/common.py
+++ b/commands/common.py
@@ -100,10 +100,14 @@ def print_help_for_command(command, state):
             print("Usage: links")
             print("Analyze all links on the current page for migration mapping.")
             return
+        case "profile":
+            print("Usage: profile")
+            print("Run provider profile URL update script.")
+            return
         case "show":
-            print("Usage: show [variables|domains|page]")
+            print("Usage: show [variables|domains|page|profile <before|after>]")
             print(
-                "Display current variables, list available domains, or show page data."
+                "Display current variables, list available domains, show page data, or open profile reports."
             )
             return
         case "clear":
@@ -157,6 +161,7 @@ def cmd_help(args, state):
     print("  check                 Analyze the current URL")
     print("  bulk_check [csv]      Process multiple pages from CSV file")
     print("  migrate               Migrate the current URL")
+    print("  profile               Update provider profile URLs from before.html")
     print(
         "  report [--force] [<domain> <row1> [<row2> ... <rowN>]]      Generate an HTML report for the page"
     )

--- a/commands/core.py
+++ b/commands/core.py
@@ -171,6 +171,30 @@ def cmd_show(args, state):
             display_page_data(state.current_page_data)
         else:
             print("❌ No page data loaded. Run 'check' first.")
+    elif target == "profile":
+        if len(args) < 2:
+            print(
+                "❌ Missing profile target. Use 'show profile before' or 'show profile after'."
+            )
+            return
+        which = args[1].lower()
+        if which not in ("before", "after"):
+            print(f"❌ Unknown profile target: {which}")
+            print("Available profile targets: before, after")
+            return
+        file_path = Path("update_provider_profile_urls") / f"{which}.html"
+        if not file_path.exists():
+            print(f"❌ File not found: {file_path}")
+            return
+        try:
+            subprocess.run(["subl", str(file_path)], check=True)
+        except Exception:
+            try:
+                _open_file_in_default_app(file_path)
+            except Exception as e:
+                print(f"❌ Failed to open file: {e}")
+                return
+        print(f"✅ Opening profile {which}: {file_path}")
     else:
         print(f"❌ Unknown show target: {target}")
-        print("Available targets: variables, domains, page")
+        print("Available targets: variables, domains, page, profile")

--- a/commands/profile.py
+++ b/commands/profile.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import subprocess
+import sys
+
+from commands.common import print_help_for_command
+
+
+def cmd_profile(args, state):
+    if args:
+        return print_help_for_command("profile", state)
+
+    script_path = Path("update_provider_profile_urls/update_provider_profile_urls.py")
+    if not script_path.exists():
+        print(f"❌ Script not found: {script_path}")
+        return
+
+    try:
+        subprocess.run([sys.executable, str(script_path)], check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Failed to run script: {e}")

--- a/constants.py
+++ b/constants.py
@@ -135,6 +135,7 @@ def get_commands(state):
     from commands.common import cmd_help, cmd_debug
     from commands.bulk import cmd_bulk_check
     from commands.check import cmd_check
+    from commands.profile import cmd_profile
 
     return {
         "bulk_check": lambda args: cmd_bulk_check(args, state),
@@ -148,6 +149,7 @@ def get_commands(state):
         "open": lambda args: cmd_open(args, state),
         "report": lambda args: cmd_report(args, state),
         "set": lambda args: cmd_set(args, state),
+        "profile": lambda args: cmd_profile(args, state),
         "sidebar": lambda args: cmd_sidebar(args, state),
         "show": lambda args: cmd_show(args, state),
         # Aliases

--- a/update_provider_profile_urls/update_provider_profile_urls.py
+++ b/update_provider_profile_urls/update_provider_profile_urls.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 from bs4 import BeautifulSoup
 
+
 def extract_first_last(name_text: str):
     # Strip off credentials after comma, e.g. "W. Scott Russell, M.D." -> "W. Scott Russell"
     name_part = name_text.split(",", 1)[0].strip()
@@ -16,7 +17,9 @@ def extract_first_last(name_text: str):
     tokens_before = tokens[:-1]
     first_name_candidate = None
     for tok in tokens_before:
-        if not re.match(r'^[A-Za-z]\.?$', tok):  # skip single-letter initials like "W." or "M."
+        if not re.match(
+            r"^[A-Za-z]\.?$", tok
+        ):  # skip single-letter initials like "W." or "M."
             first_name_candidate = tok
             break
     if first_name_candidate is None:
@@ -24,9 +27,11 @@ def extract_first_last(name_text: str):
     first_name = first_name_candidate.strip("., ").replace(".", "")
     return first_name, last_name
 
+
 def build_new_url(first_name: str, last_name: str):
     # lower-case, keep hyphens in last name
     return f"https://education.musc.edu/MUSCApps/FacultyDirectory/{last_name.lower()}-{first_name.lower()}"
+
 
 def main(input_file="before.html", output_file="after.html"):
     in_path = Path(input_file)
@@ -57,6 +62,7 @@ def main(input_file="before.html", output_file="after.html"):
 
     with open(out_path, "w", encoding="utf-8") as f:
         f.write(str(soup))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add `profile` command to run provider profile URL updater script
- extend `show` to open profile `before`/`after` HTML reports via Sublime or default app
- document new command in help output

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910d764eac832a83e4fa26e7bf2acd