### PR TITLE
Highlight robots noindex/nofollow directives in reports

### DIFF
--- a/commands/report.py
+++ b/commands/report.py
@@ -141,13 +141,25 @@ def _generate_consolidated_section(state):
             escaped_meta = escaped_meta[:200] + "..."
 
         html += f"""
-            <p><strong>Meta Description:</strong> 
+            <p><strong>Meta Description:</strong>
                 <button onclick="copyMetaDescription(event)" class="copy-btn" style="display: inline-flex;" title="Copy meta description">📋</button>
                 <span id="meta-desc-text">{escaped_meta}</span>
             </p>"""
     else:
         html += """
             <p><strong>Meta Description:</strong> <em>Not available</em></p>"""
+
+    # Add robots directives line
+    meta_robots = state.current_page_data.get("meta_robots", "")
+    robots_content = meta_robots.lower()
+    noindex_style = (
+        "color: red; font-weight: bold;" if "noindex" in robots_content else ""
+    )
+    nofollow_style = (
+        "color: red; font-weight: bold;" if "nofollow" in robots_content else ""
+    )
+    html += f"""
+            <p><span style="{noindex_style}">noindex</span>, <span style="{nofollow_style}">nofollow</span></p>"""
 
     html += f"""
         </div>

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,0 +1,13 @@
+from bs4 import BeautifulSoup
+from utils.scraping import extract_meta_robots
+
+
+def test_extract_meta_robots_found():
+    html = "<html><head><meta name='ROBOTS' content='NOINDEX, NOFOLLOW'></head></html>"
+    soup = BeautifulSoup(html, "html.parser")
+    assert extract_meta_robots(soup) == "NOINDEX, NOFOLLOW"
+
+
+def test_extract_meta_robots_missing():
+    soup = BeautifulSoup("<html><head></head></html>", "html.parser")
+    assert extract_meta_robots(soup) == ""

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -110,9 +110,13 @@ def _is_cache_valid_for_context(state, cache_file):
         if not _is_metadata_structure_current(metadata):
             return False, "Metadata structure is outdated"
 
-        # Check if page_data contains meta_description
-        if not page_data or "meta_description" not in page_data:
-            return False, "Cache missing meta description data"
+        # Check if page_data contains meta_description and meta_robots
+        if (
+            not page_data
+            or "meta_description" not in page_data
+            or "meta_robots" not in page_data
+        ):
+            return False, "Cache missing meta description or robots data"
 
         current_url = state.get_variable("URL")
         current_domain = state.get_variable("DOMAIN")

--- a/utils/scraping.py
+++ b/utils/scraping.py
@@ -61,6 +61,17 @@ def extract_meta_description(soup):
     return ""
 
 
+def extract_meta_robots(soup):
+    """Extract the meta robots directive from a BeautifulSoup object."""
+
+    meta_tag = soup.find("meta", attrs={"name": lambda x: x and x.lower() == "robots"})
+    if meta_tag and "content" in meta_tag.attrs:
+        debug_print(f"Meta robots found: {meta_tag['content']}")
+        return meta_tag["content"]
+    debug_print("No meta robots tag found")
+    return ""
+
+
 def extract_links_from_page(soup, response, selector="#main"):
     """Extract hyperlinks from a BeautifulSoup page container.
 
@@ -148,6 +159,8 @@ def retrieve_page_data(url, selector="#main", include_sidebar=False):
 
         meta_description = extract_meta_description(soup)
         debug_print(f"Meta description extracted: {meta_description}")
+        meta_robots = extract_meta_robots(soup)
+        debug_print(f"Meta robots extracted: {meta_robots}")
 
         data = {
             "links": main_links,
@@ -157,6 +170,7 @@ def retrieve_page_data(url, selector="#main", include_sidebar=False):
             "sidebar_pdfs": sidebar_pdfs,
             "sidebar_embeds": sidebar_embeds,
             "meta_description": meta_description,
+            "meta_robots": meta_robots,
         }
 
         total_main = len(main_links) + len(main_pdfs) + len(main_embeds)
@@ -181,6 +195,7 @@ def retrieve_page_data(url, selector="#main", include_sidebar=False):
             "sidebar_pdfs": [],
             "sidebar_embeds": [],
             "meta_description": "",
+            "meta_robots": "",
             "error": str(e),
             "selector_used": selector,
             "include_sidebar": include_sidebar,


### PR DESCRIPTION
## Summary
- extract and cache `<meta name="robots">` content during scraping
- show a "noindex, nofollow" line in reports and highlight directives in red if present
- validate robots info in cache and add tests for meta robots extraction

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892a61cad18832ab444bd2e9aa30f41