### PR TITLE
docs: refine docstrings

### DIFF
--- a/commands/common.py
+++ b/commands/common.py
@@ -127,7 +127,12 @@ def display_domains():
 
 
 def cmd_debug(args, state):
-    """Toggle debug mode."""
+    """Toggle debug output or set it explicitly.
+
+    With no arguments the current debug flag is inverted. Supplying
+    ``on``/``off`` (or truthy equivalents) forces the flag to the
+    desired state.
+    """
     current_debug = state.get_variable("DEBUG")
 
     if not args:

--- a/commands/load.py
+++ b/commands/load.py
@@ -70,7 +70,12 @@ def _extract_url_and_proposed_path(state, domain, row_num):
 
 @validation_wrapper
 def cmd_load(args, state, *, validated=None):
-    """Handle the 'load' command for loading URLs from spreadsheet."""
+    """Load page information from the DSM spreadsheet.
+
+    The command resolves ``<domain> <row>`` to an existing URL and proposed
+    path, updating the relevant state variables. Cached data is loaded when
+    available to avoid re-fetching page content.
+    """
     state.reset_page_context_state()
 
     if validated:

--- a/commands/sidebar.py
+++ b/commands/sidebar.py
@@ -2,7 +2,12 @@ from commands.common import print_help_for_command
 
 
 def cmd_sidebar(args, state):
-    """Toggle sidebar inclusion in page extraction."""
+    """Enable or disable sidebar processing when scraping pages.
+
+    Without arguments the current setting is toggled. Passing ``on`` or
+    ``off`` (and common truthy/falsey variants) explicitly sets the
+    ``INCLUDE_SIDEBAR`` variable.
+    """
     current_value = state.get_variable("INCLUDE_SIDEBAR")
 
     if not args:

--- a/constants.py
+++ b/constants.py
@@ -121,7 +121,12 @@ DOMAIN_MAPPING = {
 
 
 def get_commands(state):
-    """Dynamically load and return the COMMANDS dictionary."""
+    """Build a mapping of command names to callable handlers.
+
+    The command modules are imported lazily to keep start-up fast. Each
+    command name is associated with a ``lambda`` that injects the shared
+    ``state`` object when invoking the real implementation.
+    """
     from commands.core import (
         cmd_links,
         cmd_open,

--- a/data/dsm.py
+++ b/data/dsm.py
@@ -144,17 +144,23 @@ def count_http(url):
 
 
 def lookup_link_in_dsm(link_url, excel_data=None, state=None):
-    """
-    Look up a link URL in the DSM spreadsheet to find its proposed new location.
+    """Locate a link's destination within the DSM spreadsheet.
+
+    The function normalizes the supplied ``link_url`` and searches every
+    domain sheet for a matching entry. A regex pattern is used so the URL can
+    appear anywhere within the cell and optional trailing slashes are handled.
 
     Args:
-        link_url: The URL to look up (from a link on a page being migrated)
-        excel_data: Loaded Excel data (optional, will use state if not provided)
-        state: State object to get excel_data from if not provided
+        link_url: URL to search for in the DSM.
+        excel_data: Pre-loaded Excel data; ``state.excel_data`` is used when
+            this argument is ``None``.
+        state: State object providing ``excel_data`` when ``excel_data`` is not
+            supplied.
 
     Returns:
-        dict with keys: 'found', 'domain', 'row', 'existing_url', 'proposed_url', 'proposed_hierarchy'
-        Returns {'found': False} if not found
+        dict: Details about the match including ``domain``, ``row``,
+        ``existing_url``, ``proposed_url`` and ``proposed_hierarchy``. If no
+        match is found ``{"found": False}`` is returned.
     """
     debug_print(f"Looking up link in DSM: {link_url}")
 

--- a/utils/scraping.py
+++ b/utils/scraping.py
@@ -73,11 +73,22 @@ def extract_meta_robots(soup):
 
 
 def extract_links_from_page(soup, response, selector="#main"):
-    """Extract hyperlinks from a BeautifulSoup page container.
+    """Return the hyperlinks found within a page section.
 
-    This function now expects the page's ``soup`` and ``response`` objects to
-    be provided.  This avoids fetching the same page multiple times when
-    called from ``retrieve_page_data``.
+    Both the parsed ``soup`` and original ``response`` are required so that
+    relative URLs can be resolved without re-fetching the page. Links ending
+    in ``.pdf`` are returned separately from other hyperlinks.
+
+    Args:
+        soup: Parsed BeautifulSoup document for the page.
+        response: ``requests`` response object used to resolve relative URLs.
+        selector: CSS selector identifying the container to inspect. Defaults
+            to ``"#main"`` and falls back to the entire page if not found.
+
+    Returns:
+        tuple[list[tuple[str, str, str]], list[tuple[str, str, str]]]:
+        Two lists containing ``(text, href, status_code)`` tuples for regular
+        links and PDFs respectively.
     """
 
     debug_print(f"Using CSS selector: {selector}")

--- a/utils/sitecore.py
+++ b/utils/sitecore.py
@@ -29,8 +29,11 @@ def get_current_sitecore_root(existing_url: str) -> str:
 
 
 def get_proposed_sitecore_root(existing_url: str) -> str:
-    """
-    Get the proposed Sitecore root folder name based on the proposed path.
+    """Determine the Sitecore root folder for the redesigned site.
+
+    The function checks the domain of ``existing_url`` against entries in
+    :data:`DOMAINS` and returns the ``root_for_new_sitecore`` value when
+    defined. If no mapping exists the current root is returned instead.
     """
     from utils.core import debug_print
 


### PR DESCRIPTION
## Summary
- clarify DSM lookup workflow and return data
- detail command injection mapping
- expand sidebar, load, and link extraction docstrings
- document proposed Sitecore root resolution

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b28a06f8832a8fe34debf4a66dbc