### PR TITLE
Handle pages with multiple existing URLs

### DIFF
--- a/commands/report.py
+++ b/commands/report.py
@@ -122,15 +122,22 @@ def _extract_sitecore_paths(state):
     )
 
 
-def _build_source_info_html(url, domain, row, page_data):
+def _build_source_info_html(urls, domain, row, page_data):
     """Build the source information section."""
     meta_description = page_data.get("meta_description", "")
     meta_robots = page_data.get("meta_robots", "")
 
+    url_links = "<br>".join(
+        f"<a href=\"{u}\" onclick=\"window.open(this.href, '_blank', 'noopener,noreferrer,width=1200,height=1200'); return false;\">{u}</a>"
+        for u in urls
+    )
+
+    url_label = "URLs" if len(urls) > 1 else "URL"
+
     html = f"""
         <div class="source-info">
             <h3>📍 Source Information</h3>
-            <p><strong>URL:</strong> <a href="{url}" onclick="window.open(this.href, '_blank', 'noopener,noreferrer,width=1200,height=1200'); return false;">{url}</a></p>
+            <p><strong>{url_label}:</strong> {url_links}</p>
             <p><strong>DSM Location:</strong> {domain} {row}</p>
     """
 
@@ -329,7 +336,8 @@ def _build_links_summary_html(items, state):
 
 def _generate_consolidated_section(state):
     """Generate the consolidated section with enhanced link display."""
-    url = state.get_variable("URL")
+    urls = state.get_variable("EXISTING_URLS") or []
+    url = urls[0] if urls else state.get_variable("URL")
     domain = state.get_variable("DOMAIN")
     row = state.get_variable("ROW")
 
@@ -345,7 +353,9 @@ def _generate_consolidated_section(state):
         escaped_proposed_js,
     ) = _extract_sitecore_paths(state)
 
-    source_html = _build_source_info_html(url, domain, row, state.current_page_data)
+    source_html = _build_source_info_html(
+        urls or [url], domain, row, state.current_page_data
+    )
     hierarchy_html = _build_hierarchy_html(
         current_root,
         existing_segments,

--- a/state.py
+++ b/state.py
@@ -12,6 +12,7 @@ class CLIState:
     def __init__(self):
         self.variables = {
             "URL": "",
+            "EXISTING_URLS": [],
             "DOMAIN": "",
             "ROW": "",
             "KANBAN_ID": "",
@@ -39,7 +40,10 @@ class CLIState:
         name = name.upper()
         if name in self.variables:
             old_value = self.variables[name]
-            self.variables[name] = str(value) if value is not None else ""
+            if isinstance(value, (list, dict)):
+                self.variables[name] = value
+            else:
+                self.variables[name] = str(value) if value is not None else ""
             debug_print(
                 f"❤️Variable {name} changed from '{old_value}' to '{self.variables[name]}'"
             )
@@ -69,7 +73,10 @@ class CLIState:
         print("=" * 50)
         for name, value in self.variables.items():
             status = "✅ SET" if value else "❌ UNSET"
-            display_value = value[:40] + "..." if len(value) > 40 else value
+            display_value = str(value)
+            display_value = (
+                display_value[:40] + "..." if len(display_value) > 40 else display_value
+            )
             print(f"{name:20} = {display_value:45} [{status}]")
         print("=" * 50)
 
@@ -98,6 +105,7 @@ class CLIState:
     def reset_page_context_state(self):
         """Reset page-specific variables to their defaults."""
         self.variables["URL"] = ""
+        self.variables["EXISTING_URLS"] = []
         self.variables["DOMAIN"] = ""
         self.variables["ROW"] = ""
         self.variables["KANBAN_ID"] = ""

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -177,21 +177,24 @@ def test_cmd_load_success(monkeypatch, cli_state, capsys):
     cli_state.excel_data.parse.return_value = "df"
     monkeypatch.setattr(
         load_cmd,
-        "get_existing_url",
-        lambda df, row, col_name: "http://page",
+        "get_existing_urls",
+        lambda df, row, col_name: ["http://page", "http://two"],
     )
     monkeypatch.setattr(load_cmd, "get_proposed_url", lambda df, row, col_name: "/new")
     monkeypatch.setattr(load_cmd, "_update_state_from_cache", MagicMock())
-    monkeypatch.setattr(load_cmd, "count_http", lambda url: 0)
     load_cmd.cmd_load(["Enterprise", "5"], cli_state)
     assert cli_state.get_variable("URL") == "http://page"
+    assert cli_state.get_variable("EXISTING_URLS") == [
+        "http://page",
+        "http://two",
+    ]
     assert "Loaded URL" in capsys.readouterr().out
 
 
 def test_cmd_load_invalid_args(monkeypatch, cli_state, capsys):
     """Ensure validation wrapper prevents execution with bad args."""
     cli_state.excel_data = MagicMock()
-    monkeypatch.setattr(load_cmd, "get_existing_url", MagicMock())
+    monkeypatch.setattr(load_cmd, "get_existing_urls", MagicMock())
     monkeypatch.setattr(load_cmd, "get_proposed_url", MagicMock())
     load_cmd.cmd_load(["Enterprise", "bad"], cli_state)
     out = capsys.readouterr().out

--- a/tests/test_dsm.py
+++ b/tests/test_dsm.py
@@ -2,13 +2,22 @@ import pandas as pd
 from data import dsm
 
 
-def test_get_existing_url_returns_first_url():
+def test_get_existing_urls_returns_all_urls():
     df = pd.DataFrame({"EXISTING URL": ["http://one.com http://two.com"]})
-    assert dsm.get_existing_url(df, 0) == "http://one.com"
+    assert dsm.get_existing_urls(df, 0) == ["http://one.com", "http://two.com"]
 
 
-def test_get_existing_url_handles_commas_and_semicolons():
+def test_get_existing_urls_handles_commas_and_semicolons():
     df = pd.DataFrame(
         {"EXISTING URL": ["http://one.com,http://two.com;http://three.com"]}
     )
+    assert dsm.get_existing_urls(df, 0) == [
+        "http://one.com",
+        "http://two.com",
+        "http://three.com",
+    ]
+
+
+def test_get_existing_url_wrapper_returns_first():
+    df = pd.DataFrame({"EXISTING URL": ["http://one.com http://two.com"]})
     assert dsm.get_existing_url(df, 0) == "http://one.com"


### PR DESCRIPTION
## Summary
- allow DSM parsing to return all existing URLs and keep first for backward compatibility
- store `EXISTING_URLS` in CLI state and propagate through load, check, and report commands
- update tests for multi-URL mappings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893bdedfa78832a944093900cebc638