### PR TITLE
Handle Vimeo embeds and copy snippet

### DIFF
--- a/commands/report.py
+++ b/commands/report.py
@@ -250,6 +250,31 @@ def _collect_page_items(page_data):
 
 def _build_link_item_html(item_type, item, state):
     """Build the HTML for a single link/resource entry."""
+    if item_type in {"embed", "sidebar_embed"}:
+        from html import escape
+        import json
+
+        title, src = item
+        debug_print(f"Processing embed: {title} ({src})")
+        escaped_title = escape(title)
+        escaped_src = escape(src, quote=True)
+        js_src = json.dumps(src)
+        js_title = json.dumps(title)
+
+        return f"""
+                <div class="link-item">
+                    <div class="link-main">
+                        🎬 <a href="{escaped_src}" target="_blank">{escaped_title}</a>
+                        <button class="copy-btn" onclick="copyEmbedToClipboard(event, {js_src}, {js_title})" title="Copy embed HTML">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+                            </svg>
+                        </button>
+                        <span class="item-type type-{item_type.replace('_', ' ')}">[{item_type.replace('_', ' ')}]</span>
+                    </div>
+                </div>
+            """
+
     text, href, status = item
     debug_print(f"Processing item: {item_type} - {text} ({href}) with status {status}")
     try:

--- a/templates/report/script.js
+++ b/templates/report/script.js
@@ -69,3 +69,21 @@ function copyMetaDescription(e) {
       });
   }
 }
+
+function copyEmbedToClipboard(e, src, title) {
+  const match = src.match(/player\.vimeo\.com\/video\/(\d+)/);
+  const id = match ? match[1] : '';
+  const snippet = `<iframe src="https://player.vimeo.com/video/${id}?badge=0&autopause=0&player_id=0&app_id=58479&texttrack=en" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="${title}"></iframe>`;
+  navigator.clipboard
+    .writeText(snippet)
+    .then(function () {
+      e.target.closest('.copy-btn').style.background = 'mediumseagreen';
+      setTimeout(() => {
+        e.target.closest('.copy-btn').style.background = 'cornflowerblue';
+      }, 1000);
+    })
+    .catch(function (err) {
+      console.error('Could not copy embed HTML: ', err);
+      alert('Copy failed. HTML: ' + snippet);
+    });
+}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -458,8 +458,8 @@ def test_generate_consolidated_section_sidebar_items(mock_state):
     mock_state.current_page_data = {
         "sidebar_links": [("Sidebar Link", "https://sidebar.com", 200)],
         "sidebar_pdfs": [("Sidebar PDF", "https://example.com/sidebar.pdf", 200)],
-        "embeds": [("Main Embed", "https://embed.com", 200)],
-        "sidebar_embeds": [("Sidebar Embed", "https://sidebar-embed.com", 200)],
+        "embeds": [("Main Embed", "https://player.vimeo.com/video/12345")],
+        "sidebar_embeds": [("Sidebar Embed", "https://player.vimeo.com/video/67890")],
     }
     mock_state.get_variable.side_effect = lambda var: {
         "URL": "https://example.com",
@@ -476,6 +476,7 @@ def test_generate_consolidated_section_sidebar_items(mock_state):
     assert "[sidebar pdf]" in result
     assert "[embed]" in result
     assert "[sidebar embed]" in result
+    assert "copyEmbedToClipboard" in result
 
 
 # ----- validation utils tests -----

--- a/utils/core.py
+++ b/utils/core.py
@@ -205,7 +205,7 @@ def display_page_data(data):
     print(f"🎬 VIMEO EMBEDS: {len(embeds)}")
     if embeds:
         print("-" * 40)
-        for i, (embed_type, title, src) in enumerate(embeds, 1):
+        for i, (title, src) in enumerate(embeds, 1):
             print(f"{i:2}. [VIMEO] {title[:50]}")
             print(f"    → {src}")
 
@@ -215,7 +215,7 @@ def display_page_data(data):
         print()
         print(f"🎬 SIDEBAR VIMEO EMBEDS: {len(sidebar_embeds)}")
         print("-" * 40)
-        for i, (embed_type, title, src) in enumerate(sidebar_embeds, len(embeds) + 1):
+        for i, (title, src) in enumerate(sidebar_embeds, len(embeds) + 1):
             print(f"{i:2}.│[VIMEO] {title[:50]}")
             print(f"   │→ {src}")
 

--- a/utils/scraping.py
+++ b/utils/scraping.py
@@ -128,11 +128,11 @@ def extract_embeds_from_page(soup, selector="#main"):
         container = soup
     for iframe in container.find_all("iframe", src=True):
         src = iframe.get("src", "")
-        if "vimeo" in src.lower():
+        if "player.vimeo.com" in src.lower():
             title = (
                 iframe.get("title", "") or iframe.get_text(strip=True) or "Vimeo Video"
             )
-            embeds.append(("vimeo", title, src))
+            embeds.append((title, src))
             debug_print(f"Found Vimeo embed: {title}")
     return embeds
 


### PR DESCRIPTION
## Summary
- detect Vimeo embeds by locating iframes whose `src` includes `player.vimeo.com`
- display embeds without status codes and add copy button to output a Vimeo embed snippet
- adjust tests for new embed handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68941e5170d0832a8d4ffd5329215b9a