### PR TITLE
Handle Vimeo embeds and copy snippet

### DIFF
--- a/commands/report.py
+++ b/commands/report.py
@@ -250,6 +250,31 @@ def _collect_page_items(page_data):
 
 def _build_link_item_html(item_type, item, state):
     """Build the HTML for a single link/resource entry."""
+    if item_type in {"embed", "sidebar_embed"}:
+        from html import escape
+        import json
+
+        title, src = item
+        debug_print(f"Processing embed: {title} ({src})")
+        escaped_title = escape(title)
+        escaped_src = escape(src, quote=True)
+        js_src = json.dumps(src)
+        js_title = json.dumps(title)
+
+        return f"""
+                <div class="link-item">
+                    <div class="link-main">
+                        🎬 <a href="{escaped_src}" target="_blank">{escaped_title}</a>
+                        <button class="copy-btn" onclick="copyEmbedToClipboard(event, {js_src}, {js_title})" title="Copy embed HTML">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+                            </svg>
+                        </button>
+                        <span class="item-type type-{item_type.replace('_', ' ')}">[{item_type.replace('_', ' ')}]</span>
+                    </div>
+                </div>
+            """
+
     text, href, status = item
     debug_print(f"Processing item: {item_type} - {text} ({href}) with status {status}")
     try:

--- a/templates/report/script.js
+++ b/templates/report/script.js
@@ -69,3 +69,21 @@ function copyMetaDescription(e) {
       });
   }
 }
+
+function copyEmbedToClipboard(e, src, title) {
+  const match = src.match(/player\.vimeo\.com\/video\/(\d+)/);
+  const id = match ? match[1] : '';
+  const snippet = `<iframe src="https://player.vimeo.com/video/${id}?badge=0&autopause=0&player_id=0&app_id=58479&texttrack=en" frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="${title}"></iframe>`;
+  navigator.clipboard
+    .writeText(snippet)
+    .then(function () {
+      e.target.closest('.copy-btn').style.background = 'mediumseagreen';
+      setTimeout(() => {
+        e.target.closest('.copy-btn').style.background = 'cornflowerblue';
+      }, 1000);
+    })
+    .catch(function (err) {
+      console.error('Could not copy embed HTML: ', err);
+      alert('Copy failed. HTML: ' + snippet);
+    });
+}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -458,8 +458,8 @@ def test_generate_consolidated_section_sidebar_items(mock_state):
     mock_state.current_page_data = {
         "sidebar_links": [("Sidebar Link", "https://sidebar.com", 200)],
         "sidebar_pdfs": [("Sidebar PDF", "https://example.com/sidebar.pdf", 200)],
-        "embeds": [("Main Embed", "https://embed.com", 200)],
-        "sidebar_embeds": [("Sidebar Embed", "https://sidebar-embed.com", 200)],
+        "embeds": [("Main Embed", "https://player.vimeo.com/video/12345")],
+        "sidebar_embeds": [("Sidebar Embed", "https://player.vimeo.com/video/67890")],
     }
     mock_state.get_variable.side_effect = lambda var: {
         "URL": "https://example.com",
@@ -476,6 +476,7 @@ def test_generate_consolidated_section_sidebar_items(mock_state):
     assert "[sidebar pdf]" in result
     assert "[embed]" in result
     assert "[sidebar embed]" in result
+    assert "copyEmbedToClipboard" in result
 
 
 # ----- validation utils tests -----

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,5 +1,12 @@
 from bs4 import BeautifulSoup
-from utils.scraping import extract_meta_robots
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from utils.scraping import (
+    extract_meta_robots,
+    extract_links_from_page,
+    extract_embeds_from_page,
+)
 
 
 def test_extract_meta_robots_found():
@@ -11,3 +18,23 @@ def test_extract_meta_robots_found():
 def test_extract_meta_robots_missing():
     soup = BeautifulSoup("<html><head></head></html>", "html.parser")
     assert extract_meta_robots(soup) == ""
+
+
+def test_extract_embeds_and_skip_from_links():
+    html = """
+    <div id='main'>
+        <a href='http://example.com'>Regular Link</a>
+        <a href='#' data-video='12345' data-title='Sample Video'>Embed Link</a>
+    </div>
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    response = SimpleNamespace(url="http://base.com")
+
+    with patch("utils.scraping.check_status_code", return_value="200"):
+        links, pdfs = extract_links_from_page(soup, response)
+
+    assert links == [("Regular Link", "http://example.com", "200")]
+    assert pdfs == []
+
+    embeds = extract_embeds_from_page(soup)
+    assert embeds == [("Sample Video", "https://player.vimeo.com/video/12345")]

--- a/utils/core.py
+++ b/utils/core.py
@@ -205,7 +205,7 @@ def display_page_data(data):
     print(f"🎬 VIMEO EMBEDS: {len(embeds)}")
     if embeds:
         print("-" * 40)
-        for i, (embed_type, title, src) in enumerate(embeds, 1):
+        for i, (title, src) in enumerate(embeds, 1):
             print(f"{i:2}. [VIMEO] {title[:50]}")
             print(f"    → {src}")
 
@@ -215,7 +215,7 @@ def display_page_data(data):
         print()
         print(f"🎬 SIDEBAR VIMEO EMBEDS: {len(sidebar_embeds)}")
         print("-" * 40)
-        for i, (embed_type, title, src) in enumerate(sidebar_embeds, len(embeds) + 1):
+        for i, (title, src) in enumerate(sidebar_embeds, len(embeds) + 1):
             print(f"{i:2}.│[VIMEO] {title[:50]}")
             print(f"   │→ {src}")
 


### PR DESCRIPTION
## Summary
- detect Vimeo embeds represented by anchor tags with `data-video` and `data-title`
- ignore those anchors during link scraping and expose them as dedicated embeds
- add test ensuring embed anchors are excluded from links and converted to Vimeo URLs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68941e5170d0832a8d4ffd5329215b9a