### PR TITLE
Style anchor copy button with distinct colors

### DIFF
--- a/commands/report.py
+++ b/commands/report.py
@@ -317,7 +317,7 @@ def _build_link_item_html(item_type, item, state):
     link_kind = "contact" if is_contact_link else "pdf"
     if is_contact_link or is_pdf_link:
         anchor_copy_button = f"""
-                        <button class="copy-anchor-btn" onclick="copyAnchorToClipboard(event, '{copy_value}', '{text}', '{link_kind}')" title="Copy as HTML anchor">
+                        <button class="copy-anchor-btn {link_kind}" onclick="copyAnchorToClipboard(event, '{copy_value}', '{text}', '{link_kind}')" title="Copy as HTML anchor">
                             &lt;/&gt;
                         </button>"""
 

--- a/templates/report/styles.css
+++ b/templates/report/styles.css
@@ -178,14 +178,14 @@ h3 {
     align-items: center;
     font-size: 12px;
     font-weight: bold;
+}
 
-    .pdf {
-        background: #800000;
-    }
+.copy-anchor-btn.pdf {
+    background: #830202;
+}
 
-    .contact {
-        background: mediumseagreen;
-    }
+.copy-anchor-btn.contact {
+    background: mediumseagreen;
 }
 
 .copy-anchor-btn:hover {


### PR DESCRIPTION
## Summary
- Style copy anchor buttons with dedicated classes for PDF and contact links
- Apply red and green backgrounds so anchor buttons differ from regular copy button

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cd071e8a4832a9d8ce8c4dbf43f53