### PR TITLE
Show link URLs and hide hierarchy for non-Sitecore links

### DIFF
--- a/templates/report/styles.css
+++ b/templates/report/styles.css
@@ -190,6 +190,15 @@ body {
     font-style: italic;
 }
 
+.link-url {
+    margin-top: 4px;
+    margin-left: 24px;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-size: 13px;
+    color: #555;
+    overflow-wrap: anywhere;
+}
+
 @media (max-width: 768px) {
     .hierarchy-comparison {
         flex-direction: column;


### PR DESCRIPTION
## Summary
- prevent non-page links (phone, email, PDFs, etc.) from showing proposed Sitecore hierarchy in reports
- add URL preview under each link/resource with mid-string truncation
- style link URL display and test helper utilities

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a61a4daf30832a999b646d3f80cc2e