### PR TITLE
Refine link reporting

### DIFF
--- a/templates/report/styles.css
+++ b/templates/report/styles.css
@@ -206,6 +206,15 @@ h3 {
     font-style: italic;
 }
 
+.link-url {
+    margin-top: 4px;
+    margin-left: 24px;
+    font-size: 13px;
+    color: #555;
+    word-break: break-all;
+    font-family: monospace;
+}
+
 @media (max-width: 768px) {
     .hierarchy-comparison {
         flex-direction: column;


### PR DESCRIPTION
## Summary
- avoid showing proposed page hierarchy for non-page links (e.g., phone, email, PDFs)
- display shortened target URL beneath each link/resource

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a62255dfd4832aa520425b795df510