### PR TITLE
Support generic taxonomy columns in reports

### DIFF
--- a/commands/load.py
+++ b/commands/load.py
@@ -51,15 +51,17 @@ def _extract_url_and_proposed_path(state, domain, row_num):
     proposed = get_proposed_url(
         df, row_num - df_header_row, col_name=proposed_url_header
     )
-    research_taxonomy = get_column_value(
-        df, row_num - df_header_row, "RESEARCH TAXONOMY"
-    )
 
-    # sort the research taxonomy values alphabetically and join with commas
-    if research_taxonomy:
-        research_taxonomy = ", ".join(
-            sorted(map(str.strip, research_taxonomy.split(",")))
-        )
+    taxonomy = ""
+    taxonomy_cols = [
+        c for c in df.columns if isinstance(c, str) and "taxonomy" in c.lower()
+    ]
+    if taxonomy_cols:
+        taxonomy = get_column_value(df, row_num - df_header_row, taxonomy_cols[0])
+
+    # sort the taxonomy values alphabetically and join with commas
+    if taxonomy:
+        taxonomy = ", ".join(sorted(map(str.strip, taxonomy.split(","))))
 
     if not urls:
         return None, None
@@ -69,7 +71,7 @@ def _extract_url_and_proposed_path(state, domain, row_num):
     state.set_variable("PROPOSED_PATH", proposed)
     state.set_variable("DOMAIN", domain.get("full_name", "Domain Placeholder"))
     state.set_variable("ROW", str(row_num))
-    state.set_variable("RESEARCH_TAXONOMY", research_taxonomy)
+    state.set_variable("TAXONOMY", taxonomy)
 
     _update_state_from_cache(
         state, url=urls[0], domain=domain.get("full_name"), row=str(row_num)

--- a/commands/report.py
+++ b/commands/report.py
@@ -149,16 +149,16 @@ def _build_source_info_html(urls, domain, row, page_data):
     return html
 
 
-def _build_research_taxonomy_html(research_taxonomy):
-    """Build the research taxonomy section if data is available."""
-    if not research_taxonomy:
+def _build_taxonomy_html(taxonomy):
+    """Build the taxonomy section if data is available."""
+    if not taxonomy:
         return ""
 
     return f"""
-        <div class=\"research-taxonomy\">
-            <h3>🔬 Research Taxonomy</h3>
+        <div class=\"taxonomy\">
+            <h3>🔬 Taxonomy</h3>
             <ul>
-                {''.join(f'<li>{escape(t.strip())}</li>' for t in research_taxonomy.split(','))}
+                {''.join(f'<li>{escape(t.strip())}</li>' for t in taxonomy.split(','))}
             </ul>
         </div>
     """
@@ -390,8 +390,8 @@ def _generate_consolidated_section(state):
     source_html = _build_source_info_html(
         urls or [url], domain, row, state.current_page_data
     )
-    research_taxonomy = state.get_variable("RESEARCH_TAXONOMY")
-    taxonomy_html = _build_research_taxonomy_html(research_taxonomy)
+    taxonomy = state.get_variable("TAXONOMY")
+    taxonomy_html = _build_taxonomy_html(taxonomy)
     hierarchy_html = _build_hierarchy_html(
         current_root,
         existing_segments,

--- a/state.py
+++ b/state.py
@@ -22,7 +22,7 @@ class CLIState:
             "CACHE_FILE": "",
             "PROPOSED_PATH": "",
             "DEBUG": "true",
-            "RESEARCH_TAXONOMY": "",
+            "TAXONOMY": "",
         }
         self.excel_data = None
         self.current_page_data = None
@@ -111,5 +111,5 @@ class CLIState:
         self.variables["ROW"] = ""
         self.variables["KANBAN_ID"] = ""
         self.variables["PROPOSED_PATH"] = ""
-        self.variables["RESEARCH_TAXONOMY"] = ""
+        self.variables["TAXONOMY"] = ""
         debug_print("Variables reset to defaults.")

--- a/templates/report/styles.css
+++ b/templates/report/styles.css
@@ -86,7 +86,7 @@ h3 {
     margin-bottom: 16px;
 }
 
-.research-taxonomy,
+.taxonomy,
 .source-info {
     flex: 1;
 }

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -174,7 +174,9 @@ def test_cmd_links(monkeypatch, cli_state):
 
 def test_cmd_load_success(monkeypatch, cli_state, capsys):
     cli_state.excel_data = MagicMock()
-    cli_state.excel_data.parse.return_value = "df"
+    df_mock = MagicMock()
+    df_mock.columns = ["EXISTING URL", "Taxonomy", "Other"]
+    cli_state.excel_data.parse.return_value = df_mock
     monkeypatch.setattr(
         load_cmd,
         "get_existing_urls",
@@ -191,7 +193,7 @@ def test_cmd_load_success(monkeypatch, cli_state, capsys):
         "http://page",
         "http://two",
     ]
-    assert cli_state.get_variable("RESEARCH_TAXONOMY") == "Cancer"
+    assert cli_state.get_variable("TAXONOMY") == "Cancer"
     assert "Loaded URL" in capsys.readouterr().out
 
 
@@ -359,19 +361,19 @@ def test_generate_consolidated_section_with_proposed_path(mock_state):
     assert "surgery" in result
 
 
-def test_generate_consolidated_section_research_taxonomy(mock_state):
-    """Research taxonomy values should appear when provided."""
+def test_generate_consolidated_section_taxonomy(mock_state):
+    """Taxonomy values should appear when provided."""
     mock_state.current_page_data = {"links": []}
     mock_state.get_variable.side_effect = lambda var: {
         "URL": "https://example.com",
         "DOMAIN": "Test",
         "ROW": "1",
         "PROPOSED_PATH": "",
-        "RESEARCH_TAXONOMY": "Oncology; Cardiology",
+        "TAXONOMY": "Oncology; Cardiology",
     }.get(var, "")
 
     result = report_cmd._generate_consolidated_section(mock_state)
-    assert "Research Taxonomy" in result
+    assert "Taxonomy" in result
     assert "Oncology; Cardiology" in result
 
 


### PR DESCRIPTION
## Summary
- detect the first DSM column containing "taxonomy" regardless of label
- expose captured taxonomy in state and include it in generated reports
- rename template styles and tests to use the generic taxonomy field

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b8374fa0832aa3b713163f3cc08e